### PR TITLE
Bug fixes in ArrayAnnotation

### DIFF
--- a/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/interpolate/ArrayInterpolator.java
+++ b/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/interpolate/ArrayInterpolator.java
@@ -153,7 +153,7 @@ public class ArrayInterpolator {
 			assert mLemmaInfo.getLemmaType().equals(":weakeq-ext");
 			interpolants = computeWeakeqExtInterpolants(proofTerm);
 		}
-		FormulaUnLet unletter = new FormulaUnLet();
+		final FormulaUnLet unletter = new FormulaUnLet();
 		for (int i = 0; i < mNumInterpolants; i++) {
 			interpolants[i] = unletter.unlet(interpolants[i]);
 		}
@@ -703,14 +703,19 @@ public class ArrayInterpolator {
 					final Term storeIndex = getIndexFromStore(storeTerm);
 					final ApplicationTerm indexDiseq =
 							mDisequalities.get(new SymmetricPair<Term>(storeIndex, mPathIndex));
-					final Occurrence indexDiseqOcc = mInterpolator.getLiteralInfo(indexDiseq);
-					final Occurrence intersectOcc = stepOcc.intersect(indexDiseqOcc);
+					if (indexDiseq != null) {
+						final Occurrence indexDiseqOcc = mInterpolator.getLiteralInfo(indexDiseq);
+						final Occurrence intersectOcc = stepOcc.intersect(indexDiseqOcc);
 
-					mTail.closeAPath(mHead, boundaryTerm, stepOcc);
-					mTail.closeAPath(mHead, boundaryTerm, intersectOcc);
-					mTail.openAPath(mHead, boundaryTerm, intersectOcc);
-					mTail.openAPath(mHead, boundaryTerm, stepOcc);
-					mTail.addIndexDisequality(mHead, storeTerm);
+						mTail.closeAPath(mHead, boundaryTerm, stepOcc);
+						mTail.closeAPath(mHead, boundaryTerm, intersectOcc);
+						mTail.openAPath(mHead, boundaryTerm, intersectOcc);
+						mTail.openAPath(mHead, boundaryTerm, stepOcc);
+						mTail.addIndexDisequality(mHead, storeTerm);
+					} else {
+						// Otherwise indexDiseq is a trivial disequality like x = x + 1.
+						// Don't close any paths.
+					}
 				} else { // In equality steps, we just close or open A paths.
 					final LitInfo stepInfo = mInterpolator.getLiteralInfo(lit);
 					mTail.closeAPath(mHead, boundaryTerm, stepInfo);

--- a/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/theory/cclosure/CCAnnotation.java
+++ b/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/theory/cclosure/CCAnnotation.java
@@ -29,38 +29,38 @@ import de.uni_freiburg.informatik.ultimate.smtinterpol.theory.cclosure.Congruenc
 
 /**
  * Annotations for congruence-closure theory lemmata.
- * 
+ *
  * A theory lemma is annotated with a set of paths and literals on these path.
  * A special role plays the diseq literal, which is the only positive literal
  * in the clause.  In the negated clause this is the disequality that is in
  * conflict with the other equalities.
- * 
+ *
  * The main path (index 0) starts and ends with one side of the diseq literal.
- * Every step must either be explained by a literal from the clause 
+ * Every step must either be explained by a literal from the clause
  * (litsOnPaths != null), or by a congruence, i.e., there are two paths
  * explaining the equality of func and arg terms.  Trivial paths for equal func
  * or arg terms are omitted.
- *   
+ *
  * @author hoenicke
  *
  */
 public class CCAnnotation implements IAnnotation {
-	
+
 	/**
-	 * The disequality of the theory lemma.  This is the only positive atom 
+	 * The disequality of the theory lemma.  This is the only positive atom
 	 * in the generated theory clause.  If this is null, then the first and
 	 * last element in the main paths are distinct terms.
 	 */
 	CCEquality     mDiseq;
 
 	/**
-	 * A sequence of paths.  The main path with index 0 must always exist 
+	 * A sequence of paths.  The main path with index 0 must always exist
 	 * and explain the diseq.  The other paths must be in such an order
 	 * that later paths explain congruences on earlier.
 	 */
 	CCTerm[][]     mPaths;
 
-	public CCAnnotation(CCEquality diseq, Collection<SubPath> paths) {
+	public CCAnnotation(final CCEquality diseq, final Collection<SubPath> paths) {
 		super();
 		mDiseq = diseq;
 		mPaths = new CCTerm[paths.size()][];
@@ -82,6 +82,7 @@ public class CCAnnotation implements IAnnotation {
 				sb.append(comma).append(term);
 				comma = " ";
 			}
+			sb.append(')');
 		}
 		sb.append(')');
 		return sb.toString();
@@ -96,7 +97,7 @@ public class CCAnnotation implements IAnnotation {
 	}
 
 	@Override
-	public Term toTerm(Clause cls, Theory theory) {
+	public Term toTerm(final Clause cls, final Theory theory) {
 		final Term base = cls.toTerm(theory);
 		final Object[] subannots =
 				new Object[2 * mPaths.length + (mDiseq == null ? 0 : 1)];


### PR DESCRIPTION
- Handle trivial numeric disequalities
- split first path in read-over-weakeq correctly
- Don't store the main path for weakeq-ext in subPathMap;
  this equality must not be used to explain the other paths