### PR TITLE
Optimization: switch data structure from List to Set.

### DIFF
--- a/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/theory/linar/LinArSolve.java
+++ b/SMTInterpol/src/de/uni_freiburg/informatik/ultimate/smtinterpol/theory/linar/LinArSolve.java
@@ -25,6 +25,7 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -104,8 +105,8 @@ public class LinArSolve implements ITheory {
 	 * must be null.
 	 */
 	final ArrayList<BitSet> mDependentRows;
-	/** The list of all non-basic integer variables. */
-	final ArrayList<LinVar> mIntVars;
+	/** All non-basic integer variables. */
+	final Set<LinVar> mIntVars;
 	/** The literals that will be propagated. */
 	final Queue<Literal> mProplist;
 	/** The basic variables hashed by their linear combinations. */
@@ -161,7 +162,7 @@ public class LinArSolve implements ITheory {
 		mLinvars = new ScopedArrayList<>();
 		mTableaux = new ArrayList<>();
 		mDependentRows = new ArrayList<>();
-		mIntVars = new ArrayList<>();
+		mIntVars = new LinkedHashSet<>();
 		mDirty = new BitSet();
 		mProplist = new ArrayDeque<>();
 		mSuggestions = new ArrayDeque<>();


### PR DESCRIPTION
### Issue:
We noticed a potential bottleneck (quadratic runtime?) when pushing several thousand simple constraints (like `var_i == i`) and popping them after solving. In my test, the pop-operation required more time than solving the constraints.

### Solution:
Non-basic integer variables were tracked as a list in `LinArSolve.java`.
When popping levels from the solver stack,
the variables to be removed need to be searched in the list before they can be removed,
and removing from an ArrayList might need a full traversal of the list.
Using a Set allows instant access and deletion.

### Please note:
- Using a LinkedHashSet should keep the iteration order deterministic. The change should not affect any further behaviour.
- For me, it is unknown whether a variable could appear several times in the list. The new Set only tracks "one" instance.
- I could not find any helful tests for this class. I trust the developers to review my change. :-)