### PR TITLE
Add support for bv2int and for int2bv

### DIFF
--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -879,10 +879,10 @@ public class Theory {
 
 			@Override
 			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
-				assert indices.length == 1;
-				assert paramSorts.length == 1 && paramSorts[0].isNumericSort();
-				assert paramSorts[0].getName().equals("Int");
-				assert resultSort == null;
+				if (indices == null || indices.length != 1 || paramSorts.length != 1
+						|| !paramSorts[0].getName().equals("Int") || resultSort != null) {
+					return null;
+				}
 				return mBitVecSort.getSort(indices);
 			}
 		}

--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -856,6 +856,32 @@ public class Theory {
 				return paramSorts[0];
 			}
 		}
+		class Bv2IntFunction extends FunctionSymbolFactory {
+			public Bv2IntFunction(final String name) {
+				super(name);
+				assert name.equals("bv2int") : "Wrong name: " + name;
+			}
+
+			@Override
+			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
+				return mNumericSort;
+			}
+		}
+		class Int2BvFunction extends FunctionSymbolFactory {
+			public Int2BvFunction(final String name) {
+				super(name);
+				assert name.equals("int2bv") : "Wrong name: " + name;
+			}
+
+			@Override
+			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
+				assert indices.length == 1;
+				assert paramSorts.length == 1 && paramSorts[0].isNumericSort();
+				assert paramSorts[0].getName().equals("Int");
+				assert resultSort == null;
+				return mBitVecSort.getSort(indices);
+			}
+		}
 		declareInternalFunctionFactory(new FunctionSymbolFactory("concat") {
 			@Override
 			public int getFlags(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
@@ -951,6 +977,12 @@ public class Theory {
 				FunctionSymbol.INTERNAL | FunctionSymbol.CHAINABLE));
 		declareInternalFunctionFactory(new RegularBitVecFunction("bvsge", 2, mBooleanSort,
 				FunctionSymbol.INTERNAL | FunctionSymbol.CHAINABLE));
+
+		declareInternalFunctionFactory(new Bv2IntFunction("bv2int"));
+		declareInternalFunctionFactory(new Int2BvFunction("int2bv"));
+
+
+
 	}
 
 	private void createFloatingPointOperators() {

--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -856,10 +856,10 @@ public class Theory {
 				return paramSorts[0];
 			}
 		}
-		class Bv2IntFunction extends FunctionSymbolFactory {
-			public Bv2IntFunction(final String name) {
+		class Bv2NatFunction extends FunctionSymbolFactory {
+			public Bv2NatFunction(final String name) {
 				super(name);
-				assert name.equals("bv2int") : "Wrong name: " + name;
+				assert name.equals("bv2nat") : "Wrong name: " + name;
 			}
 
 			@Override
@@ -871,10 +871,10 @@ public class Theory {
 				return mNumericSort;
 			}
 		}
-		class Int2BvFunction extends FunctionSymbolFactory {
-			public Int2BvFunction(final String name) {
+		class Nat2BvFunction extends FunctionSymbolFactory {
+			public Nat2BvFunction(final String name) {
 				super(name);
-				assert name.equals("int2bv") : "Wrong name: " + name;
+				assert name.equals("nat2bv") : "Wrong name: " + name;
 			}
 
 			@Override
@@ -982,8 +982,8 @@ public class Theory {
 		declareInternalFunctionFactory(new RegularBitVecFunction("bvsge", 2, mBooleanSort,
 				FunctionSymbol.INTERNAL | FunctionSymbol.CHAINABLE));
 
-		declareInternalFunctionFactory(new Bv2IntFunction("bv2int"));
-		declareInternalFunctionFactory(new Int2BvFunction("int2bv"));
+		declareInternalFunctionFactory(new Bv2NatFunction("bv2nat"));
+		declareInternalFunctionFactory(new Nat2BvFunction("nat2bv"));
 
 
 

--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -864,7 +864,7 @@ public class Theory {
 
 			@Override
 			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
-				if (indices != null || paramSorts.length != 1 || !paramSorts[0].getName() != "BitVec" || resultSort != null) {
+				if (indices != null || paramSorts.length != 1 || paramSorts[0].getName() != "BitVec" || resultSort != null) {
 					return null;
 				}
 				return mNumericSort;				

--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -864,7 +864,10 @@ public class Theory {
 
 			@Override
 			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
-				return mNumericSort;
+				if (indices != null || paramSorts.length != 1 || !paramSorts[0].getName() != "BitVec" || resultSort != null) {
+					return null;
+				}
+				return mNumericSort;				
 			}
 		}
 		class Int2BvFunction extends FunctionSymbolFactory {

--- a/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
+++ b/Library-SMTLIB/src/de/uni_freiburg/informatik/ultimate/logic/Theory.java
@@ -864,10 +864,11 @@ public class Theory {
 
 			@Override
 			public Sort getResultSort(final String[] indices, final Sort[] paramSorts, final Sort resultSort) {
-				if (indices != null || paramSorts.length != 1 || paramSorts[0].getName() != "BitVec" || resultSort != null) {
+				if (indices != null || paramSorts.length != 1 || paramSorts[0].getName() != "BitVec"
+						|| resultSort != null) {
 					return null;
 				}
-				return mNumericSort;				
+				return mNumericSort;
 			}
 		}
 		class Int2BvFunction extends FunctionSymbolFactory {


### PR DESCRIPTION
* Both functions are not (yet?) in the SMT-LIB standard.
* Z3 supports both functions.
* We want to utilize this functions internally for our translation from bitvectors to integers.
* As an alternative, people also discuss the functions bv2nat and nat2bv. https://groups.google.com/g/smt-lib/c/-GJG1Pq61hI However, I strongly prefer a totally defined function over a partially defined function.